### PR TITLE
Fix " Fatal error: [] operator not supported for strings"

### DIFF
--- a/SVGCaptcha.php
+++ b/SVGCaptcha.php
@@ -256,6 +256,7 @@ EOD;
                     $packed[$key]['glyph_data'][] = $shape;
                 }
             }
+            $this->captcha_answer = array();
             $this->captcha_answer[] = $key;
         }
 


### PR DESCRIPTION
This change fixes line 259 in newer versions of PHP